### PR TITLE
Fix lint: use ctrl.Log instead of s.log

### DIFF
--- a/azure/scope/arocontrolplane.go
+++ b/azure/scope/arocontrolplane.go
@@ -573,7 +573,7 @@ func (s *AROControlPlaneScope) GetKeyVaultResourceID() string {
 				vaultNamePath = []string{"spec", "properties", "etcd", "dataEncryption", "customerManaged", "kms", "vaultName"}
 			default:
 				// Unknown API version — use latest known path, but log for observability
-				s.log.V(2).Info("unknown HcpOpenShiftCluster API version for vault name extraction, using latest known path", "apiVersion", apiVersion)
+				ctrl.Log.V(2).Info("unknown HcpOpenShiftCluster API version for vault name extraction, using latest known path", "apiVersion", apiVersion)
 				vaultNamePath = []string{"spec", "properties", "etcd", "dataEncryption", "customerManaged", "kms", "vaultName"}
 			}
 			name, found, err := unstructured.NestedString(


### PR DESCRIPTION
## Summary
- `AROControlPlaneScope` has no `log` field, causing `typecheck` lint failure
- Replace `s.log` with `ctrl.Log` (global controller-runtime logger), consistent with the rest of the file (lines 373, 381)

## Test plan
- [x] Fixes `golangci-lint` typecheck error in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)